### PR TITLE
Add sanitize parameter to icon url

### DIFF
--- a/helm/snapscheduler/Chart.yaml
+++ b/helm/snapscheduler/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: snapscheduler
 # Chart version: Incremented during chart, template, or appVersion changes.
-version: "1.0.0"
+version: "1.0.1"
 description: >-
     An operator to take scheduled snapshots of Kubernetes persistent volumes
 type: application
@@ -20,6 +20,6 @@ maintainers:
   - name: John Strunk
     email: jstrunk@redhat.com
     url: https://github.com/JohnStrunk
-icon: https://raw.githubusercontent.com/backube/snapscheduler/master/docs/media/snapscheduler.svg
+icon: https://raw.githubusercontent.com/backube/snapscheduler/master/docs/media/snapscheduler.svg?sanitize=true
 # This is the version number of the application being deployed.
 appVersion: "1.0.0"


### PR DESCRIPTION
**Describe what this PR does**
Github won't serve SVG by default unless sanitize=true is passed in the
url. This tells it to remove embedded javascript.

Updates chart to 1.0.1

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
