### PR TITLE
Fix Failed to watch *v1.PersistentVolumeClaim

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -64,3 +64,4 @@ rules:
   verbs:
   - get
   - list
+  - watch

--- a/helm/snapscheduler/Chart.yaml
+++ b/helm/snapscheduler/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: snapscheduler
 # Chart version: Incremented during chart, template, or appVersion changes.
-version: "1.0.1"
+version: "1.0.2"
 description: >-
     An operator to take scheduled snapshots of Kubernetes persistent volumes
 type: application

--- a/helm/snapscheduler/templates/role.yaml
+++ b/helm/snapscheduler/templates/role.yaml
@@ -63,3 +63,4 @@ rules:
   verbs:
   - get
   - list
+  - watch


### PR DESCRIPTION
**Describe what this PR does**
The operator didn't have permission to watch() v1.PVC. While the
operator code doesn't directly create such a watch, it is happening in
client-go. This adds the permission to the ClusterRole for the operator.

Also bumps the chart version since it's a change to the chart.

**Related issues:**
Fixes #55 
