### PR TITLE
Add retries to install in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Install prereqs
         run: |
+          echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
           sudo apt-get update
           sudo apt-get install -y python-pip ruby
           sudo gem install asciidoctor mdl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
           sudo apt-get update
-          sudo apt-get install -y python-pip ruby
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip ruby
           sudo gem install asciidoctor mdl
           sudo pip install yamllint
 


### PR DESCRIPTION
**Describe what this PR does**
Tests have been flaky due to failures of apt-get when installing
prereqs. This adds a few retries to see if that helps.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
