### PR TITLE
Correct release date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project follows [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
-## [1.1.0] - 2019-02-12
+## [1.1.0] - 2019-02-13
 
 ### Added
 


### PR DESCRIPTION
**Describe what this PR does**
Switch changelog to today's date for v1.1.0 release

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
