### PR TITLE
Add 1.18 to list of kube versions in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
       matrix:
         # There must be kindest/node images for these versions
         # See: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
-        KUBERNETES_VERSIONS: ["1.13.12", "1.14.10", "1.15.7", "1.16.4", "1.17.0"]
+        KUBERNETES_VERSIONS: ["1.13.12", "1.14.10", "1.15.7", "1.16.4", "1.17.0", "1.18.0"]
 
     env:
       KUBECONFIG: /tmp/kubeconfig

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -119,7 +119,13 @@ if [[ $KUBE_MINOR -lt 14 ]]; then
         git pull --unshallow && git pull
         git checkout "v1.1.0"
 fi
-"${HP_BASE}/deploy/kubernetes-1.$KUBE_MINOR"/deploy-hostpath.sh
+
+DEPLOY_PATH="${HP_BASE}/deploy/kubernetes-1.${KUBE_MINOR}/"
+if [[ $KUBE_MINOR -ge 17 ]]; then
+  # 1.17 & 1.18 use the same path
+  DEPLOY_PATH="${HP_BASE}/deploy/kubernetes-1.17/"
+fi
+"${DEPLOY_PATH}/deploy-hostpath.sh"
 rm -rf "${HP_BASE}"
 
 CSI_DRIVER_NAME="hostpath.csi.k8s.io"


### PR DESCRIPTION
**Describe what this PR does**
Adds kube 1.18.0 to CI test matrix

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #87 