### PR TITLE
Helm updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   GO_VERSION: "1.13"
-  HELM_VERSION: "3.0.2"
+  HELM_VERSION: "3.2.0"
   KIND_VERSION: "0.7.0"
   OPERATOR_SDK_VERSION: "0.15.1"
-  GOLANGCI_VERSION: "1.23.3"
+  GOLANGCI_VERSION: "1.25.0"
   GO111MODULE: "on"
   IMAGE: "quay.io/backube/snapscheduler"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install prereqs
         run: |
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install Go
         uses: actions/setup-go@v1
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install Helm
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Container image to build
 IMAGE := quay.io/backube/snapscheduler
 # Version of golangci-lint to install (if asked)
-GOLANGCI_VERSION := v1.23.3
+GOLANGCI_VERSION := v1.25.0
 # Version of operator-sdk to install (if asked)
 OPERATOR_SDK_VERSION := v0.15.1
 GOBINDIR := $(shell go env GOPATH)/bin

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -90,7 +90,7 @@ rm -f "${KIND_CONFIG_FILE}"
 
 # Kube >= 1.17, we need to deploy the snapshot controller
 if [[ $KUBE_MINOR -ge 17 ]]; then
-  TAG="v2.0.1"
+  TAG="v2.1.0"
   kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
   kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
   kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"

--- a/helm/snapscheduler/Chart.yaml
+++ b/helm/snapscheduler/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: snapscheduler
 # Chart version: Incremented during chart, template, or appVersion changes.
-version: "1.1.0"
+version: "1.2.0"
 description: >-
     An operator to take scheduled snapshots of Kubernetes persistent volumes
 type: application

--- a/helm/snapscheduler/README.md
+++ b/helm/snapscheduler/README.md
@@ -129,7 +129,7 @@ case, the defaults, shown below, should be sufficient.
   - Allows setting the operator container's security context
 - `resources`: requests for 10m CPU and 100Mi memory; no limits
   - Allows overriding the resource requests/limits for the operator pod
-- `nodeSelector`: none
+- `nodeSelector`: `kubernetes.io/arch: amd64`, `kubernetes.io/os: linux`
   - Allows applying a node selector to the operator pod
 - `tolerations`: none
   - Allows applying tolerations to the operator pod

--- a/helm/snapscheduler/templates/NOTES.txt
+++ b/helm/snapscheduler/templates/NOTES.txt
@@ -1,6 +1,9 @@
-Thank you for installing snapscheduler!
+Thank you for installing SnapScheduler!
 
-The snapscheduler operator is now installed in the {{ .Release.Namespace }}
+Chart version: {{ .Chart.Version }}
+SnapScheduler version: {{ default .Chart.AppVersion .Values.image.tagOverride }}
+
+The SnapScheduler operator is now installed in the {{ .Release.Namespace }}
 namespace, and snapshotschedules should be enabled cluster-wide.
 
 See https://backube.github.io/snapscheduler/usage.html to get started.

--- a/helm/snapscheduler/templates/deployment.yaml
+++ b/helm/snapscheduler/templates/deployment.yaml
@@ -38,10 +38,31 @@ spec:
               value: "snapscheduler"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+  {{- /*
+  The horrible-ness below related to nodeSelector is because the node labels
+  removed the beta prefix in 1.14.
+  We want to have a default that ensures amd64/linux by default, but users must
+  be able to override that, including removing all selectors. If we didn't have
+  to determine at render-time the proper label name, the default labels should
+  be in the values.yaml and the template would look just like affinity, below.
+  The values.yaml file would set the labels like it does for resources.
+  When support for 1.13 is dropped, please fix this!
+  */ -}}
+  {{- if quote .Values.nodeSelector | ne "" }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- else }}
+      nodeSelector:
+      {{- if semverCompare ">=1.14" .Capabilities.KubeVersion.Version }}
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      {{- else }}
+        beta.kubernetes.io/arch: amd64
+        beta.kubernetes.io/os: linux
+      {{- end }}
+  {{- end }}
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -27,7 +27,13 @@ resources:
     cpu: 10m
     memory: 100Mi
 
-nodeSelector: {}
+# nodeSelector specifies the set of nodes where the operator can run. By
+# default, the operator is restricted to amd64/linux nodes. If a value is
+# provided here, it overrides that default. Also, by specifying {} for the
+# value, the default can be cleared entirely. The default isn't shown here since
+# the proper node labels must be determined dynamically due to differences
+# between kube 1.13 and later.
+nodeSelector:
 
 tolerations: []
 


### PR DESCRIPTION
**Describe what this PR does**
Updates the helm chart to:
- Print the chart and operator (image tag) version when installing
- Default to having a node selector for amd64/linux nodes since we don't build multi-arch images

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #75
Fixes #78