### PR TITLE
Change helm min kube version to allow prerelease kube

### DIFF
--- a/helm/snapscheduler/Chart.yaml
+++ b/helm/snapscheduler/Chart.yaml
@@ -6,8 +6,9 @@ version: "1.2.0"
 description: >-
     An operator to take scheduled snapshots of Kubernetes persistent volumes
 type: application
-# Minimum kube version 1.13
-kubeVersion: "^1.13"
+# Adding "-0" at the end of the version string permits pre-release kube versions
+# to match. See https://github.com/helm/helm/issues/6190
+kubeVersion: "^1.13.0-0"
 keywords:
   - csi
   - scheduler


### PR DESCRIPTION
**Describe what this PR does**
The previous `kubeVersion` semver in the Helm chart incorrectly disallowed installation on prerelease Kubernetes versions. This change makes prerelease versions ok.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
