### PR TITLE
Add kube 1.19 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,7 +153,7 @@ jobs:
       matrix:
         # There must be kindest/node images for these versions
         # See: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
-        KUBERNETES_VERSIONS: ["1.13.12", "1.14.10", "1.15.7", "1.16.4", "1.17.0", "1.18.0"]
+        KUBERNETES_VERSIONS: ["1.13.12", "1.14.10", "1.15.7", "1.16.9", "1.17.5", "1.18.8", "1.19.0"]
 
     env:
       KUBECONFIG: /tmp/kubeconfig

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,8 @@ Kubernetes version compatibility:
 | snapscheduler | Kubernetes    | `snapshot.storage.k8s.io` |
 |---------------|---------------|---------------------------|
 | 1.0           | 1.13 -- 1.16  | `v1alpha1`                |
-| 1.1           | 1.13 -- 1.18+ | `v1alpha1`, `v1beta1`     |
-| master        | 1.13 -- 1.18+ | `v1alpha1`, `v1beta1`     |
+| 1.1           | 1.13 -- 1.19+ | `v1alpha1`, `v1beta1`     |
+| master        | 1.13 -- 1.19+ | `v1alpha1`, `v1beta1`     |
 
 ## Contents
 


### PR DESCRIPTION
**Describe what this PR does**
Adds kube 1.19 to the CI test matrix and updates older kube versions to latest z release (that's available for kind).

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
