### PR TITLE
Include kube 1.20 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
       matrix:
         # There must be kindest/node images for these versions
         # See: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
-        KUBERNETES_VERSIONS: ["1.13.12", "1.14.10", "1.15.7", "1.16.9", "1.17.5", "1.18.8", "1.19.0"]
+        KUBERNETES_VERSIONS: ["1.13.12", "1.14.10", "1.15.12", "1.16.15", "1.17.11", "1.18.8", "1.19.4", "1.20.0"]
 
     env:
       KUBECONFIG: /tmp/kubeconfig
@@ -199,9 +199,23 @@ jobs:
       - name: Run e2e tests
         run: make e2e
 
+  # This is a dummy job that can be used to determine success of CI:
+  # - by Mergify instead of having to list a bunch of other jobs
+  # - by the push jobs to ensure all pre-reqs pass before ANY containers are
+  #   pushed.
+  # - by branch protection so it doesn't need to be updated each time the kube
+  #   versions in the matrix change
+  e2e-success:
+    name: Successful e2e tests
+    needs: [build, e2e, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "Previous steps were successful"
+
   push:
     name: Push container to registry
-    needs: [build, e2e]
+    needs: [e2e-success]
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,14 +50,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-        with:
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
-
-      - name: Checkout PR head
-        if: ${{ github.event_name == 'pull_request' }}
-        run: git checkout HEAD^2
 
       - name: Install Go
         uses: actions/setup-go@v1

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
 # skopeo inspect docker://kindest/node:v1.17.0 | jq .RepoTags
-KUBE_VERSION="${1:-1.19.0}"
+KUBE_VERSION="${1:-1.20.0}"
 
 # Determine the Kube minor version
 [[ "${KUBE_VERSION}" =~ ^[0-9]+\.([0-9]+) ]] && KUBE_MINOR="${BASH_REMATCH[1]}" || exit 1
@@ -89,8 +89,16 @@ kind create cluster ${KIND_CONFIG} --image "kindest/node:v${KUBE_VERSION}"
 rm -f "${KIND_CONFIG_FILE}"
 
 # Kube >= 1.17, we need to deploy the snapshot controller
-if [[ $KUBE_MINOR -ge 17 ]]; then
-  TAG="v3.0.0"
+if [[ $KUBE_MINOR -ge 20 ]]; then
+  TAG="v4.0.0"  # https://github.com/kubernetes-csi/external-snapshotter/releases
+  kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
+  kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
+  kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"
+
+  kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml"
+  kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml"
+elif [[ $KUBE_MINOR -ge 17 ]]; then
+  TAG="v3.0.3"  # https://github.com/kubernetes-csi/external-snapshotter/releases
   kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
   kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
   kubectl create -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${TAG}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"


### PR DESCRIPTION
**Describe what this PR does**
- Fixes CI for 1.17+ due to release of snapshot controller
- Adds 1.20 to test matrix

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
