### PR TITLE
Fix metrics service

### DIFF
--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
 # skopeo inspect docker://kindest/node:v1.17.0 | jq .RepoTags
-KUBE_VERSION="${1:-1.20.0}"
+KUBE_VERSION="${1:-1.20.2}"
 
 # Determine the Kube minor version
 [[ "${KUBE_VERSION}" =~ ^[0-9]+\.([0-9]+) ]] && KUBE_MINOR="${BASH_REMATCH[1]}" || exit 1
@@ -124,12 +124,16 @@ case "$KUBE_MINOR" in
     HOSTPATH_BRANCH="v1.2.0"
     DEPLOY_SCRIPT="deploy-hostpath.sh"
     ;;
-  15|16|17)
+  15)
     HOSTPATH_BRANCH="v1.3.0"
     DEPLOY_SCRIPT="deploy-hostpath.sh"
     ;;
+  16|17)
+    HOSTPATH_BRANCH="v1.4.0"
+    DEPLOY_SCRIPT="deploy.sh"
+    ;;
   *)
-    HOSTPATH_BRANCH="master"
+    HOSTPATH_BRANCH="v1.6.0"
     DEPLOY_SCRIPT="deploy.sh"
     ;;
 esac

--- a/helm/snapscheduler/templates/deployment.yaml
+++ b/helm/snapscheduler/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tagOverride }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              name: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
   {{- /*
@@ -74,8 +77,8 @@ metadata:
     {{- include "snapscheduler.labels" . | nindent 4 }}
 spec:
   ports:
-  - name: https
-    port: 8443
-    targetPort: https
+  - name: http
+    port: 8080
+    targetPort: http
   selector:
     {{- include "snapscheduler.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
**Describe what this PR does**
Previously, the chart created a Service for metrics, but the port didn't match that of the metrics endpoint in the operator Deployment.
This adds the metrics port to the list of container ports and updates the Service to connect to it.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #116 