### PR TITLE
Fix artifact hub link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docs.](https://backube.github.io/snapscheduler/)
 The operator can be installed from:
 
 - [Artifact
-  Hub](https://artifacthub.io/package/chart/backube-helm-charts/snapscheduler)
+  Hub](https://artifacthub.io/packages/helm/backube-helm-charts/snapscheduler)
 - [OperatorHub.io](https://operatorhub.io/operator/snapscheduler)
 
 Other helpful links:


### PR DESCRIPTION
**Describe what this PR does**
Fixes the link to the Helm chart in Artifact Hub

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
