### PR TITLE
Increase timeout from multi-pvc e2e

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,6 +5,12 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: manager-config
-  files:
+- files:
   - controller_manager_config.yaml
+  name: manager-config
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: quay.io/backube/snapscheduler
+  newTag: latest

--- a/test-kuttl/e2e/multi-pvc/10-waitfor-snapshot.yaml
+++ b/test-kuttl/e2e/multi-pvc/10-waitfor-snapshot.yaml
@@ -2,12 +2,12 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - timeout: 90
+  - timeout: 180
     script: |
       set -e -o pipefail
 
       echo "Waiting for 2 snapshots"
-      while [[ $(kubectl -n "$NAMESPACE" get volumesnapshots -oname | wc -l) != 2 ]]; do
+      while [[ $(kubectl -n "$NAMESPACE" get volumesnapshots -oname | wc -l) -lt 2 ]]; do
         sleep 1
       done
 


### PR DESCRIPTION
**Describe what this PR does**
The multi-pvc test has been failing frequently in CI, but passes locally. This increases the timeout to give the GH runner a bit more time.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
