### PR TITLE
Add chart option to disable metrics auth

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,6 +164,7 @@ jobs:
         run: |
           bin/helm install --create-namespace -n backube-snapscheduler \
               --set image.tagOverride=ci-build \
+              --set metrics.disableAuth=true \
               --wait --timeout=300s \
               snapscheduler ./helm/snapscheduler
           kubectl -n backube-snapscheduler get all

--- a/hack/run-in-kind.sh
+++ b/hack/run-in-kind.sh
@@ -14,5 +14,7 @@ IMAGE="quay.io/backube/snapscheduler"
 docker tag "${IMAGE}:latest" "${IMAGE}:${KIND_TAG}"
 kind load docker-image "${IMAGE}:${KIND_TAG}"
 
-kubectl create ns backube-snapscheduler
-helm install -n backube-snapscheduler --set image.tagOverride=${KIND_TAG} snapscheduler ./helm/snapscheduler
+helm upgrade --install --create-namespace -n backube-snapscheduler \
+    --set image.tagOverride=${KIND_TAG} \
+    --set metrics.disableAuth=true \
+    snapscheduler ./helm/snapscheduler

--- a/helm/snapscheduler/templates/clusterrole-metrics-reader.yaml
+++ b/helm/snapscheduler/templates/clusterrole-metrics-reader.yaml
@@ -1,4 +1,4 @@
----
+{{- if not .Values.metrics.disableAuth }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -10,3 +10,4 @@ rules:
   - /metrics
   verbs:
   - get
+{{- end }}

--- a/helm/snapscheduler/templates/clusterrole-proxy.yaml
+++ b/helm/snapscheduler/templates/clusterrole-proxy.yaml
@@ -1,4 +1,4 @@
----
+{{- if not .Values.metrics.disableAuth }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,3 +18,4 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+{{- end }}

--- a/helm/snapscheduler/templates/deployment.yaml
+++ b/helm/snapscheduler/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
           - --upstream=http://127.0.0.1:8080/
           - --logtostderr=true
           - --v=10
+            {{- if .Values.metrics.disableAuth }}
+          - --ignore-paths=/metrics
+            {{- end }}
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
           name: kube-rbac-proxy
           ports:

--- a/helm/snapscheduler/templates/rolebinding-proxy.yaml
+++ b/helm/snapscheduler/templates/rolebinding-proxy.yaml
@@ -1,4 +1,4 @@
----
+{{- if not .Values.metrics.disableAuth }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -13,3 +13,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "snapscheduler.fullname" . }}-proxy
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/snapscheduler/templates/service-metrics.yaml
+++ b/helm/snapscheduler/templates/service-metrics.yaml
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    {{- include "snapscheduler.labels" . | nindent 4 }}
+    {{- include "snapscheduler.selectorLabels" . | nindent 4 }}

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -36,3 +36,7 @@ nodeSelector:
 tolerations: []
 
 affinity: {}
+
+metrics:
+  # Disable auth checks when scraping metrics (allow anyone to scrape)
+  disableAuth: false

--- a/test-kuttl/e2e/metrics/00-assert.yaml
+++ b/test-kuttl/e2e/metrics/00-assert.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+collectors:
+  # Operator logs
+  - selector: app.kubernetes.io/name=snapscheduler
+    namespace: backube-snapscheduler
+  # Resources in the test namespace
+  - type: command
+    command: kubectl -n $NAMESPACE get all,pvc,snapshotschedule,volumesnapshot,volumesnapshotcontent -oyaml
+  # Logs from the job
+  - type: command
+    command: kubectl -n $NAMESPACE logs --prefix --all-containers job/check-metrics
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-metrics
+status:
+  succeeded: 1

--- a/test-kuttl/e2e/metrics/00-check-metrics.yaml
+++ b/test-kuttl/e2e/metrics/00-check-metrics.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-metrics
+spec:
+  template:
+    spec:
+      containers:
+        - name: busybox
+          image: busybox
+          command: ["/bin/sh", "-c"]
+          args: ["wget -O- --no-check-certificate -q https://snapscheduler-metrics.backube-snapscheduler.svc.cluster.local:8443/metrics | grep -q 'workqueue_work_duration_seconds_count{name=\"snapshotschedule\"}'"]
+      restartPolicy: Never


### PR DESCRIPTION
**Describe what this PR does**
Adds an option to the Helm chart to disable authentication of the `/metrics` endpoint.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
