### PR TITLE
Allow setting service account annotations

### DIFF
--- a/helm/snapscheduler/templates/serviceaccount.yaml
+++ b/helm/snapscheduler/templates/serviceaccount.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ include "snapscheduler.serviceAccountName" . }}
   labels:
     {{- include "snapscheduler.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -14,6 +14,8 @@ fullnameOverride: ""
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Annotations to add to the service account.
+  annotations: {}
   # The name of the service account to use. If not set and create is true, a
   # name is generated using the fullname template
   name:


### PR DESCRIPTION
**Describe what this PR does**
Allow users to define service account annotations. This is particularly useful for EKS->IAM integration.

**Is there anything that requires special attention?**
N/A.

**Related issues:**
N/A.
