### PR TITLE
Add permissions for so codeql passes w/ restricted gh action permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,8 @@ jobs:
   codescan:
     name: CodeQL scan
     runs-on: ubuntu-20.04
+    permissions:
+      security-events: write
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
**Describe what this PR does**
The GH action permissions have been set to restrictive. This change grants necessary permissions so that the CodeQL job can run

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
