### PR TITLE
make rbac proxy image configurable

### DIFF
--- a/helm/snapscheduler/templates/deployment.yaml
+++ b/helm/snapscheduler/templates/deployment.yaml
@@ -31,8 +31,9 @@ spec:
             {{- if .Values.metrics.disableAuth }}
           - --ignore-paths=/metrics
             {{- end }}
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-          name: kube-rbac-proxy
+          image: "{{ .Values.rbacProxyImage.repository }}:{{ .Values.rbacProxyImage.tag }}"
+          imagePullPolicy: {{ .Values.rbacProxyImage.pullPolicy }}
+          name: {{ .Values.rbacProxyImage.name }}
           ports:
           - containerPort: 8443
             name: https

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -11,6 +11,13 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+rbacProxyImage:
+  name: kube-rbac-proxy
+
+  repository: gcr.io/kubebuilder/kube-rbac-proxy
+  tag: "v0.8.0"
+  pullPolicy: IfNotPresent
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
**Describe what this PR does**
This PR adds the ability to set a custom image for the kube-rbac-proxy. This is useful when you cannot use public Docker registries.

**Is there anything that requires special attention?**
N/A.

**Related issues:**
N/A.
