### PR TITLE
Add resource config for the kube-rbac-proxy container.

### DIFF
--- a/helm/snapscheduler/README.md
+++ b/helm/snapscheduler/README.md
@@ -119,6 +119,9 @@ case, the defaults, shown below, should be sufficient.
   - Overrides the container image pull policy
 - `imagePullSecrets`: none
   - May be set if pull secret(s) are needed to retrieve the operator image
+- `rbacProxy.resources`: requests for 10m CPU and 100Mi memory; no limits
+  - Allows overriding the resource requests/limits for the kube-rbac-proxy
+    container of the operator pod.
 - `serviceAccount.create`: `true`
   - Whether to create the ServiceAccount for the operator
 - `serviceAccount.name`: none
@@ -128,7 +131,8 @@ case, the defaults, shown below, should be sufficient.
 - `securityContext`: none
   - Allows setting the operator container's security context
 - `resources`: requests for 10m CPU and 100Mi memory; no limits
-  - Allows overriding the resource requests/limits for the operator pod
+  - Allows overriding the resource requests/limits for the manager
+    container of the operator pod.
 - `nodeSelector`: `kubernetes.io/arch: amd64`, `kubernetes.io/os: linux`
   - Allows applying a node selector to the operator pod
 - `tolerations`: none

--- a/helm/snapscheduler/templates/deployment.yaml
+++ b/helm/snapscheduler/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
           ports:
           - containerPort: 8443
             name: https
+          resources:
+            {{- toYaml .Values.rbacProxy.resources | nindent 12 }}
         - args:
           - --health-probe-bind-address=:8081
           - --metrics-bind-address=127.0.0.1:8080

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -11,6 +11,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+rbacProxy:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Signed-off-by: Henrik Lundahl <henrik.lundahl@gmail.com>

**Describe what this PR does**

Enables setting/overriding resources for the kube-rbac-proxy container.

**Is there anything that requires special attention?**

I hope the defaults are ok.

**Related issues:**

#140 will need to adapt if this is merged first.
