### PR TITLE
Remove unnecessary doc dependencies

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -3,16 +3,4 @@ source "https://rubygems.org"
 #   bundle update
 #   bundle exec jekyll serve -w -l
 
-# Current github-pages version: https://pages.github.com/versions/
-gem "github-pages", "~> 226", group: :jekyll_plugins
-
-# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
-# and associated library.
-install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
-  gem "tzinfo", "~> 2.0"
-  gem "tzinfo-data"
-end
-
-# Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
-
+gem "github-pages", group: :jekyll_plugins

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,9 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22.5)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (6.0.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     coffee-script (2.4.1)
@@ -227,7 +230,7 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    multi_json (1.15.0)
+    minitest (5.15.0)
     multipart-post (2.1.1)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
@@ -259,26 +262,22 @@ GEM
       unf (~> 0.1.4)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
-      concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2022.1)
-      tzinfo (>= 1.0.0)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.1)
     unicode-display_width (1.8.0)
-    wdm (0.1.1)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (~> 226)
-  tzinfo (~> 2.0)
-  tzinfo-data
-  wdm (~> 0.1.1)
+  github-pages
 
 BUNDLED WITH
-   2.2.22
+   2.2.33


### PR DESCRIPTION
**Describe what this PR does**
- Removes some unnecessary Gem dependencies for building on windows
- Removal permits updating activesupport to fix vulnerabilities

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
