### PR TITLE
Update cron-regex in CRD to be more permissive

### DIFF
--- a/config/crd/bases/snapscheduler.backube_snapshotschedules.yaml
+++ b/config/crd/bases/snapscheduler.backube_snapshotschedules.yaml
@@ -118,7 +118,7 @@ spec:
                 description: Schedule is a Cronspec specifying when snapshots should
                   be taken. See https://en.wikipedia.org/wiki/Cron for a description
                   of the format.
-                pattern: ^((\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}|@(hourly|daily|weekly|monthly|yearly))$
+                pattern: ^(@(annually|yearly|monthly|weekly|daily|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7})$
                 type: string
               snapshotTemplate:
                 description: A template to customize the Snapshots.

--- a/helm/snapscheduler/crds/snapscheduler.backube_snapshotschedules.yaml
+++ b/helm/snapscheduler/crds/snapscheduler.backube_snapshotschedules.yaml
@@ -118,7 +118,7 @@ spec:
                 description: Schedule is a Cronspec specifying when snapshots should
                   be taken. See https://en.wikipedia.org/wiki/Cron for a description
                   of the format.
-                pattern: ^((\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}|@(hourly|daily|weekly|monthly|yearly))$
+                pattern: ^(@(annually|yearly|monthly|weekly|daily|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7})$
                 type: string
               snapshotTemplate:
                 description: A template to customize the Snapshots.


### PR DESCRIPTION
Allows for ranges and slash notations.

Signed-off-by: Wolfgang Jentner <10183885+wjentner@users.noreply.github.com>

**Describe what this PR does**
<!-- Provide some context for the reviewer -->

Updates the RegEx evaluating the cron syntax to be more permissive, such that ranges and slash notations are allowed.
The `@every` syntax is not working in the current implementation, it is therefore removed from the RegEx.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
Related: #229 