### PR TITLE
tests: Add periodic job to trigger other workflows

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -1,0 +1,42 @@
+---
+# yamllint disable rule:line-length
+
+# We want to have our active branches built periodically to ensure they continue
+# to build correctly, and to pick up any updates to underlying packages/images.
+# Unfortunately, GitHub only allows scheduled workflow runs against the
+# "default" branch (main). This job, residing on the default branch, will
+# trigger other jobs (across other branches) at a regular interval.
+#
+# Jobs triggered by this workflow:
+# - Must have "workflow_dispatch" as a trigger method
+# - Must either:
+#   - Be on the default branch OR
+#   - Have executed at least once previously
+#
+# The above conditions are met in our case since we're just trying to
+# periodically trigger workflows that run with each PR/Push.
+name: Periodic
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: "15 6 * * 1"  # 6:15 every Monday
+  workflow_dispatch:  # Useful for testing, but not necessary
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: write
+  contents: read
+  metadata: read
+
+jobs:
+  trigger-workflows:
+    name: Trigger other workflows
+    runs-on: ubuntu-latest
+
+    steps:
+      # Must checkout source or gh can't figure out what to trigger
+      - name: Checkout source
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Trigger workflows
+        run: |
+          gh workflow run --ref "master" "tests.yml"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
       - release*
-  schedule:
-    - cron: "15 6 * * 1"  # 6:15 every Monday
+  workflow_dispatch:
 
 env:
   GO_VERSION: "1.18"
@@ -243,7 +242,7 @@ jobs:
     name: Push container to registry
     needs: [e2e-success]
     if: >
-      (github.event_name == 'push' || github.event_name == 'schedule') &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
 
@@ -269,14 +268,14 @@ jobs:
 
       - name: Push to registry (latest)
         if: >
-          (github.event_name == 'push' || github.event_name == 'schedule') &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
           github.ref == 'refs/heads/master'
         run: |
           docker push "${IMAGE}"
 
       - name: Push to registry (version tag)
         if: >
-          (github.event_name == 'push' || github.event_name == 'schedule') &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
           startsWith(github.ref, 'refs/tags/v')
         run: |
           [[ "${{ github.ref }}" =~ ^refs/tags/v([0-9]+\..*) ]] || exit 0


### PR DESCRIPTION
**Describe what this PR does**
Moves the periodic triggering of builds on master to a separate workflow file so that we can also trigger release branches and tag rebuilds (eventually).

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
