### PR TITLE
helm: Allow specifying containers by sha hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project follows [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+
+- Ability to specify a container hash instead of just a tag when deploying via
+  Helm chart
+
 ### Changed
 
 - Made CRD validation of cronspec more permissive

--- a/helm/snapscheduler/Chart.yaml
+++ b/helm/snapscheduler/Chart.yaml
@@ -29,6 +29,8 @@ annotations:
   # Changelog for current chart & app version
   # Supported kinds: added, changed, deprecated, removed, fixed, security
   artifacthub.io/changes: |
+    - kind: added
+      description: Added ability to specify a container hash instead of just a tag
     - kind: changed
       description: Made CRD validation of cronspec more permissive
     - kind: changed

--- a/helm/snapscheduler/README.md
+++ b/helm/snapscheduler/README.md
@@ -111,6 +111,9 @@ case, the defaults, shown below, should be sufficient.
     via leader election.
 - `image.repository`: `quay.io/backube/snapscheduler`
   - The location of the operator container image
+- `image.image`: `""`
+  - If set, it will override the `.repository` and `.tagOverride` fields to
+    allow specifying a specific container and SHA to deploy
 - `image.tagOverride`: `""`
   - If set, it will override the operator container image tag. The default tag
     is set per chart version and can be viewed (as `appVersion`) via `helm show
@@ -121,8 +124,11 @@ case, the defaults, shown below, should be sufficient.
   - May be set if pull secret(s) are needed to retrieve the operator image
 - `rbacProxy.image.repository`: `quay.io/brancz/kube-rbac-proxy`
   - Specifies the container image used for the RBAC proxy
-- `rbacProxy.image.tag`: `v0.11.0`
+- `rbacProxy.image.tag`: (see values file for default tag)
   - Specifies the tag for the RBAC proxy container image
+- `rbacProxy.image.image`: `""`
+  - If set, it will override the `.repository` and `.tag` fields to
+    allow specifying a specific container and SHA to deploy
 - `rbacProxy.image.pullPolicy`: `IfNotPresent`
   - Specifies the RBAC proxy container image pull policy
 - `rbacProxy.resources`: requests for 10m CPU and 100Mi memory; no limits

--- a/helm/snapscheduler/README.md
+++ b/helm/snapscheduler/README.md
@@ -37,7 +37,7 @@ for more information.
 
 ## Requirements
 
-- Kubernetes >= 1.17
+- Kubernetes >= 1.20
 - CSI-based storage driver that supports snapshots (i.e. has the
   `CREATE_DELETE_SNAPSHOT` capability)
 

--- a/helm/snapscheduler/templates/_helpers.tpl
+++ b/helm/snapscheduler/templates/_helpers.tpl
@@ -61,3 +61,23 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "snapscheduler.image" -}}
+{{- with .Values.image }}
+{{- if .image -}}
+{{ .image }}
+{{- else -}}
+{{ .repository }}:{{ default $.Chart.AppVersion .tagOverride }}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- define "rbacproxy.image" -}}
+{{- with .Values.rbacProxy.image }}
+{{- if .image -}}
+{{ .image }}
+{{- else -}}
+{{ .repository }}:{{ .tag }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/snapscheduler/templates/deployment.yaml
+++ b/helm/snapscheduler/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             {{- if .Values.metrics.disableAuth }}
           - --ignore-paths=/metrics
             {{- end }}
-          image: "{{ .Values.rbacProxy.image.repository }}:{{ .Values.rbacProxy.image.tag }}"
+          image: {{ include "rbacproxy.image" . }}
           imagePullPolicy: {{ .Values.rbacProxy.image.pullPolicy }}
           name: kube-rbac-proxy
           ports:
@@ -47,7 +47,7 @@ spec:
           - --leader-elect
           command:
           - /manager
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tagOverride }}"
+          image: {{ include "snapscheduler.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -5,6 +5,7 @@ replicaCount: 1
 image:
   repository: quay.io/backube/snapscheduler
   tagOverride: ""
+  image: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -15,6 +16,7 @@ rbacProxy:
   image:
     repository: quay.io/brancz/kube-rbac-proxy
     tag: v0.13.1
+    image: ""
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
**Describe what this PR does**
Adds a `.image` field to the chart's values file so that a full container image w/ hash can be specified

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #252 