### PR TITLE
Helm: Make the chart manage CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@ This project follows [Semantic Versioning](https://semver.org/)
 
 ### Changed
 
+- :warning: Helm chart now directly manages CRD installation/upgrade  
+  If upgrading from 3.1.0 or earlier, manual steps are required:
+
+  ```console
+  Error: UPGRADE FAILED: rendered manifests contain a resource that already
+  exists. Unable to continue with update: CustomResourceDefinition
+  "snapshotschedules.snapscheduler.backube" in namespace "" exists and cannot be
+  imported into the current release: invalid ownership metadata; label
+  validation error: missing key "app.kubernetes.io/managed-by": must be set to
+  "Helm"; annotation validation error: missing key "meta.helm.sh/release-name":
+  must be set to "snapscheduler"; annotation validation error: missing key
+  "meta.helm.sh/release-namespace": must be set to "backube-snapscheduler"
+  ```
+
+  The above error can be fixed by adding the required labels and annotations as
+  mentioned in the error message:
+
+  ```console
+  $ kubectl label crd/snapshotschedules.snapscheduler.backube app.kubernetes.io/managed-by=Helm
+  customresourcedefinition.apiextensions.k8s.io/snapshotschedules.snapscheduler.backube labeled
+
+  $ kubectl annotate crd/snapshotschedules.snapscheduler.backube meta.helm.sh/release-name=snapscheduler
+  customresourcedefinition.apiextensions.k8s.io/snapshotschedules.snapscheduler.backube annotated
+
+  $ kubectl annotate crd/snapshotschedules.snapscheduler.backube meta.helm.sh/release-namespace=backube-snapscheduler
+  customresourcedefinition.apiextensions.k8s.io/snapshotschedules.snapscheduler.backube annotated
+  ```
+
 - Made CRD validation of cronspec more permissive
 - Upgrade quay.io/brancz/kube-rbac-proxy to v0.13.1
 - Upgrade operator-sdk to 1.23.0

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,14 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	cp config/crd/bases/* helm/snapscheduler/crds
+	@{ \
+	for SRC in config/crd/bases/*.yaml; do \
+		DST="helm/snapscheduler/templates/$$(basename "$$SRC")"; \
+		echo "{{- if .Values.manageCRDs }}" > "$$DST"; \
+		cat "$$SRC" >> "$$DST"; \
+		echo "{{- end }}" >> "$$DST"; \
+	done; \
+	}
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/v1/snapshotschedule_types.go
+++ b/api/v1/snapshotschedule_types.go
@@ -79,7 +79,7 @@ type SnapshotScheduleSpec struct {
 	Retention SnapshotRetentionSpec `json:"retention,omitempty"`
 	// Schedule is a Cronspec specifying when snapshots should be taken. See
 	// https://en.wikipedia.org/wiki/Cron for a description of the format.
-	//+kubebuilder:validation:Pattern=`^((\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}|@(hourly|daily|weekly|monthly|yearly))$`
+	//+kubebuilder:validation:Pattern=`^(@(annually|yearly|monthly|weekly|daily|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*)\s?){5,7})$`
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Schedule",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Schedule string `json:"schedule,omitempty"`
 	// Indicates that this schedule should be temporarily disabled

--- a/config/crd/bases/snapscheduler.backube_snapshotschedules.yaml
+++ b/config/crd/bases/snapscheduler.backube_snapshotschedules.yaml
@@ -118,7 +118,7 @@ spec:
                 description: Schedule is a Cronspec specifying when snapshots should
                   be taken. See https://en.wikipedia.org/wiki/Cron for a description
                   of the format.
-                pattern: ^(@(annually|yearly|monthly|weekly|daily|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7})$
+                pattern: ^(@(annually|yearly|monthly|weekly|daily|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*)\s?){5,7})$
                 type: string
               snapshotTemplate:
                 description: A template to customize the Snapshots.

--- a/helm/snapscheduler/Chart.yaml
+++ b/helm/snapscheduler/Chart.yaml
@@ -32,6 +32,8 @@ annotations:
     - kind: added
       description: Added ability to specify a container hash instead of just a tag
     - kind: changed
+      description: Helm chart now directly manages CRD installation/upgrade
+    - kind: changed
       description: Made CRD validation of cronspec more permissive
     - kind: changed
       description: Upgrade operator-sdk to 1.23.0

--- a/helm/snapscheduler/README.md
+++ b/helm/snapscheduler/README.md
@@ -71,6 +71,37 @@ $ kubectl -n <mynampspace> get snapshotschedules
 ...
 ```
 
+### ⚠️ Upgrade notice... ⚠️
+
+If upgrading from v3.1.0 or earlier, manual steps are required. When upgrading
+from versions 3.1.0 and earlier, the `helm upgrade ...` command will fail with
+the following error:
+
+```console
+Error: UPGRADE FAILED: rendered manifests contain a resource that already
+exists. Unable to continue with update: CustomResourceDefinition
+"snapshotschedules.snapscheduler.backube" in namespace "" exists and cannot be
+imported into the current release: invalid ownership metadata; label validation
+error: missing key "app.kubernetes.io/managed-by": must be set to "Helm";
+annotation validation error: missing key "meta.helm.sh/release-name": must be
+set to "snapscheduler"; annotation validation error: missing key
+"meta.helm.sh/release-namespace": must be set to "backube-snapscheduler"
+```
+
+The above error can be fixed by adding the required labels and annotations as
+mentioned in the error message:
+
+```console
+$ kubectl label crd/snapshotschedules.snapscheduler.backube app.kubernetes.io/managed-by=Helm
+customresourcedefinition.apiextensions.k8s.io/snapshotschedules.snapscheduler.backube labeled
+
+$ kubectl annotate crd/snapshotschedules.snapscheduler.backube meta.helm.sh/release-name=snapscheduler
+customresourcedefinition.apiextensions.k8s.io/snapshotschedules.snapscheduler.backube annotated
+
+$ kubectl annotate crd/snapshotschedules.snapscheduler.backube meta.helm.sh/release-namespace=backube-snapscheduler
+customresourcedefinition.apiextensions.k8s.io/snapshotschedules.snapscheduler.backube annotated
+```
+
 ## Examples
 
 The schedule for snapshotting is controlled by the
@@ -122,6 +153,9 @@ case, the defaults, shown below, should be sufficient.
   - Overrides the container image pull policy
 - `imagePullSecrets`: none
   - May be set if pull secret(s) are needed to retrieve the operator image
+- `manageCRDs`: `true`
+  - Whether the chart should automatically install, upgrade, or remove the
+    SnapshotSchedule CRD
 - `rbacProxy.image.repository`: `quay.io/brancz/kube-rbac-proxy`
   - Specifies the container image used for the RBAC proxy
 - `rbacProxy.image.tag`: (see values file for default tag)

--- a/helm/snapscheduler/crds/snapscheduler.backube_snapshotschedules.yaml
+++ b/helm/snapscheduler/crds/snapscheduler.backube_snapshotschedules.yaml
@@ -118,7 +118,7 @@ spec:
                 description: Schedule is a Cronspec specifying when snapshots should
                   be taken. See https://en.wikipedia.org/wiki/Cron for a description
                   of the format.
-                pattern: ^(@(annually|yearly|monthly|weekly|daily|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7})$
+                pattern: ^(@(annually|yearly|monthly|weekly|daily|hourly))|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*)\s?){5,7})$
                 type: string
               snapshotTemplate:
                 description: A template to customize the Snapshots.

--- a/helm/snapscheduler/templates/snapscheduler.backube_snapshotschedules.yaml
+++ b/helm/snapscheduler/templates/snapscheduler.backube_snapshotschedules.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.manageCRDs }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -180,3 +181,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -77,3 +77,5 @@ affinity:
 metrics:
   # Disable auth checks when scraping metrics (allow anyone to scrape)
   disableAuth: false
+
+manageCRDs: true


### PR DESCRIPTION
**Describe what this PR does**
Moves the CRDs to be treated as normal templates in the chart so that they can be installed, upgraded, and removed as appropriate so that they stay in sync with the operator.

**Is there anything that requires special attention?**
NOTE: This is a breaking change for users upgrading from v3.1.0 or earlier. They will need to manually annotate/label the CRDs in order for the upgrade to succeed.

**Related issues:**
Fixes #253 