### PR TITLE
CI: Disable rebuilds of tagged 3.2.0

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -47,4 +47,4 @@ jobs:
           gh workflow run --ref "release-3.2" "tests.yml"
 
           # Rebuilds of tagged containers
-          gh workflow run --ref "v3.2.0" "tests.yml"
+          # gh workflow run --ref "v3.2.0" "tests.yml"  # Disabled due to mdl config incompatibility


### PR DESCRIPTION
**Describe what this PR does**
Due to the mdl breaking change, we cannot do container rebuilds for this tag.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
