### PR TITLE
Helm chart: Option to set a priorityClassName

### DIFF
--- a/helm/snapscheduler/templates/deployment.yaml
+++ b/helm/snapscheduler/templates/deployment.yaml
@@ -83,3 +83,6 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: 10
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -79,3 +79,6 @@ metrics:
   disableAuth: false
 
 manageCRDs: true
+
+# ref: https://kubernetes.io/blog/2023/01/12/protect-mission-critical-pods-priorityclass/
+priorityClassName: ""

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -80,5 +80,6 @@ metrics:
 
 manageCRDs: true
 
-# ref: https://kubernetes.io/blog/2023/01/12/protect-mission-critical-pods-priorityclass/
+# See https://kubernetes.io/blog/2023/01/12/
+#        protect-mission-critical-pods-priorityclass/
 priorityClassName: ""


### PR DESCRIPTION
**Describe what this PR does**
Introduces the option to set a priorityClassName for the deployment on Kubernetes

**Is there anything that requires special attention?**
No, this PR does not change the default behavior (= no priorityClassName set)

Compare the output of these command:
- Default behavior: `helm template .`
- PriorityClassName set: `helm template --set=priorityClassName=system-cluster-critical .`

**Related issues:**
issue #347 
