### PR TITLE
fix: docker buildx takes a single parameter: the directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
**Describe what this PR does**
Fixes `docker-buildx` target. I'm not sure why this parameter was left out. If I generate a Makefile with Operator SDK, it is present.
