### PR TITLE
Support for pod labels and annotations

### DIFF
--- a/helm/snapscheduler/Chart.yaml
+++ b/helm/snapscheduler/Chart.yaml
@@ -2,9 +2,9 @@
 apiVersion: v2
 name: snapscheduler
 # Chart version: Incremented during chart, template, or appVersion changes.
-version: "3.2.0"
+version: "3.3.0"
 description: >-
-    An operator to take scheduled snapshots of Kubernetes persistent volumes
+  An operator to take scheduled snapshots of Kubernetes persistent volumes
 type: application
 # Adding "-0" at the end of the version string permits pre-release kube versions
 # to match. See https://github.com/helm/helm/issues/6190

--- a/helm/snapscheduler/README.md
+++ b/helm/snapscheduler/README.md
@@ -188,3 +188,7 @@ case, the defaults, shown below, should be sufficient.
     topology domain(s) that each Node is in.
 - `affinity`: node-level anti-affinity
   - Allows setting the operator pod's affinity
+- `podLabels`: `{}`
+  - map of additional labels to add to pods
+- `podAnnotations`: `{}`
+  - map of additional annotations to add to pods

--- a/helm/snapscheduler/templates/deployment.yaml
+++ b/helm/snapscheduler/templates/deployment.yaml
@@ -14,6 +14,13 @@ spec:
       labels:
         backube/snapscheduler-affinity: manager
         {{- include "snapscheduler.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -36,6 +36,12 @@ podSecurityContext:
   # seccompProfile:
   #   type: RuntimeDefault
 
+# additional annotations to add to pods
+podAnnotations: {}
+
+# additional labels to add to pods
+podLabels: {}
+
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
**Describe what this PR does**
Adds support for adding additional pod labels and annotations to the snapscheduler pod.  Adding key value pairs to the `podLabels` and `podAnnotations` variables will add them to the template's deployment spec.

**Is there anything that requires special attention?**
N/A

**Related issues:**
closes #157 
