### PR TITLE
Update kind to v0.20.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   GO_VERSION: "1.21"
-  KIND_VERSION: "0.17.0"
+  KIND_VERSION: "0.20.0"
   GO111MODULE: "on"
   IMAGE: "quay.io/backube/snapscheduler"
 
@@ -160,15 +160,17 @@ jobs:
       fail-fast: false
       matrix:
         # There must be kindest/node images for these versions
-        # See: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
+        # See: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=last_updated
         KUBERNETES_VERSIONS:
           - "1.20.15"
           - "1.21.14"
-          - "1.22.15"
-          - "1.23.13"
-          - "1.24.7"
-          - "1.25.3"
-          - "1.26.0"
+          - "1.22.17"
+          - "1.23.17"
+          - "1.24.15"
+          - "1.25.11"
+          - "1.26.6"
+          - "1.27.3"
+          - "1.28.0"
 
     env:
       KUBECONFIG: /tmp/kubeconfig
@@ -194,8 +196,8 @@ jobs:
         run: |
           curl -LO "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
           sudo install ./kubectl /usr/local/bin/
-          kubectl version --short --client
-          kubectl version --short --client | grep -q ${KUBERNETES_VERSION}
+          kubectl version --client
+          kubectl version --client | grep -q ${KUBERNETES_VERSION}
 
       - name: Install kind
         run: |

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Kubernetes version compatibility:
 | 3.0           | 1.20 -- 1.24+ | `v1`                      |
 | 3.1           | 1.20 -- 1.24+ | `v1`                      |
 | 3.2           | 1.20 -- 1.25+ | `v1`                      |
-| master        | 1.20 -- 1.25+ | `v1`                      |
+| master        | 1.20 -- 1.28+ | `v1`                      |
 
 ## Contents
 

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
 # skopeo list-tags docker://kindest/node
-KUBE_VERSION="${1:-1.26.0}"
+KUBE_VERSION="${1:-1.28.0}"
 
 function log {
   echo "=====  $*  ====="
@@ -163,7 +163,7 @@ rm -f "${KIND_CONFIG_FILE}"
 
 # Kube >= 1.17, we need to deploy the snapshot controller
 if [[ $KUBE_MINOR -ge 24 ]]; then  # Kube 1.24 removed snapshot.storage.k8s.io/v1beta1
-  TAG="v6.2.1"  # https://github.com/kubernetes-csi/external-snapshotter/releases
+  TAG="v6.2.2"  # https://github.com/kubernetes-csi/external-snapshotter/releases
   log "Deploying external snapshotter: ${TAG}"
   kubectl create -k "https://github.com/kubernetes-csi/external-snapshotter/client/config/crd?ref=${TAG}"
   kubectl create -n kube-system -k "https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref=${TAG}"


### PR DESCRIPTION
**Describe what this PR does**
- Update kind to v0.20.0
- Adds kube 1.27 & 1.28 to the test matrix
- Upgrades external snapshotter to v6.2.2

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
