### PR TITLE
Switch to fedora for e2e metrics test

### DIFF
--- a/test-kuttl/e2e/metrics/00-check-metrics.yaml
+++ b/test-kuttl/e2e/metrics/00-check-metrics.yaml
@@ -6,16 +6,16 @@ metadata:
 spec:
   containers:
     - name: workload
-      image: gcr.io/distroless/static:debug-nonroot
+      image: fedora:latest
       command: ["sh", "-c"]
-      args: ["wget -O- --no-check-certificate -q https://snapscheduler-metrics.backube-snapscheduler.svc.cluster.local:8443/metrics | grep 'workqueue_work_duration_seconds_count{name=\"snapshotschedule\"}'"]
+      args: ["curl --insecure https://snapscheduler-metrics.backube-snapscheduler.svc.cluster.local:8443/metrics | grep 'workqueue_work_duration_seconds_count{name=\"snapshotschedule\"}'"]
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
           drop: ["ALL"]
+        runAsUser: 1000
+        runAsGroup: 1000
         readOnlyRootFilesystem: true
-        # seccompProfile:
-        #   type: RuntimeDefault
   restartPolicy: OnFailure
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
**Describe what this PR does**
Switches to a fedora image and from wget to curl to test the metrics endpoint

For some reason, wget is unable to negotiate the TLS connection to the rbac proxy container. curl has no problem though.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
