### PR TITLE
Add `metadata.namespace` to Kubernetes resources

### DIFF
--- a/helm/snapscheduler/templates/deployment.yaml
+++ b/helm/snapscheduler/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "snapscheduler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snapscheduler.labels" . | nindent 4 }}
 spec:

--- a/helm/snapscheduler/templates/role-leader-election.yaml
+++ b/helm/snapscheduler/templates/role-leader-election.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "snapscheduler.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snapscheduler.labels" . | nindent 4 }}
 rules:

--- a/helm/snapscheduler/templates/rolebinding-leader-election.yaml
+++ b/helm/snapscheduler/templates/rolebinding-leader-election.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "snapscheduler.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snapscheduler.labels" . | nindent 4 }}
 roleRef:

--- a/helm/snapscheduler/templates/service-metrics.yaml
+++ b/helm/snapscheduler/templates/service-metrics.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "snapscheduler.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snapscheduler.labels" . | nindent 4 }}
 spec:

--- a/helm/snapscheduler/templates/serviceaccount.yaml
+++ b/helm/snapscheduler/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "snapscheduler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snapscheduler.labels" . | nindent 4 }}
 {{- end -}}


### PR DESCRIPTION
**Describe what this PR does**

This MR adds the `metadata.namespace` value to all namespaced Kubernetes resources.

While this is a common practice seen in most public helm charts, my particular desire for this change is to enable deploying this chart via [ArgoCD](https://argo-cd.readthedocs.io/en/stable/).

Without this change I see the following ArgoCD errors
![Screenshot from 2024-05-08 08-28-09](https://github.com/backube/snapscheduler/assets/59538148/3ecf88d3-7ede-4f82-8301-60e372e21239)

Whereas with the change, I see successful syncs
![Screenshot from 2024-05-08 08-20-58](https://github.com/backube/snapscheduler/assets/59538148/b08a98e7-9599-4f93-b22c-25b5620ab8d8)

**Is there anything that requires special attention?**

It's more typical to see `{{ .Release.Namespace | quote }}` used. However, I chose not to use this because this chart already has examples of using just `{{ .Release.Namespace }}`: https://github.com/backube/snapscheduler/blob/v3.3.0/helm/snapscheduler/templates/rolebinding.yaml#L10