### PR TITLE
Add multi-arch container image support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,28 +94,40 @@ jobs:
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
 
   build:
-    name: Build
+    name: Build (${{ matrix.ARCH }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ARCH: [amd64, arm64, s390x, ppc64le]
 
     steps:
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
+      - name: Set up QEMU
+        if: matrix.ARCH != 'amd64'
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build operator container
-        run: make docker-build IMAGE=${IMAGE}
-
-      - name: Export container image
-        run: docker save -o /tmp/image.tar ${IMAGE}
+        run: |
+          VERSION=$(git describe --tags --dirty --match 'v*' 2>/dev/null || git describe --always --dirty)
+          BUILDDATE=$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
+          docker buildx build \
+            --platform "linux/${{ matrix.ARCH }}" \
+            --build-arg "version=${VERSION}" \
+            --build-arg "builddate=${BUILDDATE}" \
+            --output "type=docker,dest=/tmp/image.tar" \
+            -t "${IMAGE}" \
+            -f Dockerfile .
 
       - name: Save container as artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: container
+          name: container-${{ matrix.ARCH }}
           path: /tmp/image.tar
 
   test:
@@ -218,7 +230,7 @@ jobs:
       - name: Load container artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: container
+          name: container-amd64
           path: /tmp
 
       - name: Import container image
@@ -263,16 +275,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Load container artifact
+      - name: Load container artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: container
           path: /tmp
-
-      - name: Import container image
-        run: |
-          docker load -i /tmp/image.tar
-          docker inspect ${IMAGE}
+          pattern: container-*
 
       - name: Login to registry
         # If the registry server is specified in the image name, we use that.
@@ -282,20 +289,30 @@ jobs:
           echo "Attempting docker login to: ${REGISTRY}"
           echo "${{ secrets.REGISTRY_PASSWORD }}" | docker login -u "${{ secrets.REGISTRY_USERNAME }}" --password-stdin ${REGISTRY}
 
-      - name: Push to registry (latest)
-        if: >
-          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-          github.ref == 'refs/heads/master'
+      - name: Determine tag
+        id: tag
         run: |
-          docker push "${IMAGE}"
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref }}" =~ ^refs/tags/v([0-9]+\..*)$ ]]; then
+            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Push to registry (version tag)
-        if: >
-          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-          startsWith(github.ref, 'refs/tags/v')
+      - name: Load, tag, and push per-arch images
         run: |
-          [[ "${{ github.ref }}" =~ ^refs/tags/v([0-9]+\..*) ]] || exit 0
-          TAG="${BASH_REMATCH[1]}"
-          echo "Pushing to $TAG"
-          docker tag "${IMAGE}" "${IMAGE}:${TAG}"
-          docker push "${IMAGE}:${TAG}"
+          TAG="${{ steps.tag.outputs.tag }}"
+          for arch in amd64 arm64 s390x ppc64le; do
+            docker load -i "/tmp/container-${arch}/image.tar"
+            docker tag "${IMAGE}" "${IMAGE}:${TAG}-${arch}"
+            docker push "${IMAGE}:${TAG}-${arch}"
+          done
+
+      - name: Create and push manifest
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          docker manifest create "${IMAGE}:${TAG}" \
+            "${IMAGE}:${TAG}-amd64" \
+            "${IMAGE}:${TAG}-arm64" \
+            "${IMAGE}:${TAG}-s390x" \
+            "${IMAGE}:${TAG}-ppc64le"
+          docker manifest push "${IMAGE}:${TAG}"

--- a/bundle/manifests/snapscheduler.clusterserviceversion.yaml
+++ b/bundle/manifests/snapscheduler.clusterserviceversion.yaml
@@ -275,10 +275,6 @@ spec:
                   requiredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
-                      - key: kubernetes.io/arch
-                        operator: In
-                        values:
-                        - amd64
                       - key: kubernetes.io/os
                         operator: In
                         values:
@@ -348,7 +344,6 @@ spec:
                     drop:
                     - ALL
               nodeSelector:
-                kubernetes.io/arch: amd64
                 kubernetes.io/os: linux
               securityContext:
                 runAsNonRoot: true

--- a/config/crd/bases/snapscheduler.backube_snapshotschedules.yaml
+++ b/config/crd/bases/snapscheduler.backube_snapshotschedules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: snapshotschedules.snapscheduler.backube
 spec:
   group: snapscheduler.backube

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,13 +40,6 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                    - amd64
-                    # - arm64
-                    # - ppc64le
-                    # - s390x
                 - key: kubernetes.io/os
                   operator: In
                   values:
@@ -98,5 +91,4 @@ spec:
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       nodeSelector:
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux

--- a/helm/snapscheduler/README.md
+++ b/helm/snapscheduler/README.md
@@ -182,7 +182,7 @@ case, the defaults, shown below, should be sufficient.
 - `resources`: requests for 10m CPU and 100Mi memory; no limits
   - Allows overriding the resource requests/limits for the manager
     container of the operator pod.
-- `nodeSelector`: `kubernetes.io/arch: amd64`, `kubernetes.io/os: linux`
+- `nodeSelector`: `kubernetes.io/os: linux`
   - Allows applying a node selector to the operator pod
 - `tolerations`: none
   - Allows applying tolerations to the operator pod

--- a/helm/snapscheduler/templates/snapscheduler.backube_snapshotschedules.yaml
+++ b/helm/snapscheduler/templates/snapscheduler.backube_snapshotschedules.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: snapshotschedules.snapscheduler.backube
 spec:
   group: snapscheduler.backube

--- a/helm/snapscheduler/values.yaml
+++ b/helm/snapscheduler/values.yaml
@@ -59,7 +59,6 @@ resources:
     memory: 100Mi
 
 nodeSelector:
-  kubernetes.io/arch: amd64
   kubernetes.io/os: linux
 
 tolerations: []


### PR DESCRIPTION
## Summary

Adds multi-arch container image support for `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le`.

Closes #372

## Changes

- **CI build job**: Replaced the single-platform `docker build` with a matrix job that builds all four architectures using Docker Buildx and QEMU
- **CI push job**: Pushes per-arch images and assembles them into a manifest list via `docker manifest create`
- **Deployment configs**: Removed `kubernetes.io/arch` constraints from Helm values, kustomize manager config, and OLM bundle CSV — with multi-arch images those aren't needed anymore (Or should those be kept for backwards compat?). Only `kubernetes.io/os: linux` is retained, following the pattern used by [cert-manager](https://github.com/cert-manager/cert-manager/blob/v1.20.1/deploy/charts/cert-manager/values.yaml#L497-L498) and [ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.15.1/charts/ingress-nginx/values.yaml#L336-L337).

## Build time

Cross-compilation via QEMU takes up to ~18 minutes for the non-amd64 architectures (amd64 builds in ~1.5 minutes natively). The image builds currently block E2E tests since GitHub Actions doesn't support [depending on a single matrix entry](https://github.com/orgs/community/discussions/42335). This could be changed by splitting into separate `build-amd64` and `build-cross` jobs, but the added duplication isn't worth the complexity IMHO.

## Testing

Validated end-to-end on [our fork](https://github.com/niledatabase/snapscheduler) by temporarily swapping `quay.io/backube/snapscheduler` for `ghcr.io/niledatabase/snapscheduler` to test the full build + push pipeline:

- Master push (publishes `latest` manifest): https://github.com/niledatabase/snapscheduler/actions/runs/23814407119
- Tag push `v99.0.0-test` (publishes version-tagged manifest): https://github.com/niledatabase/snapscheduler/actions/runs/23815806152

Both runs show all four architectures building, E2E passing on amd64, and the manifest list pushed successfully.

<details>
<summary><code>docker manifest inspect ghcr.io/niledatabase/snapscheduler:latest</code></summary>

```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3233,
         "digest": "sha256:cbc75c031b313175a3db5ee86c4d297ba54a02ba910a9a2c8b3115294661df3f",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3233,
         "digest": "sha256:75f275e0fa55093e236f8ecbf88ce704a619c9d06793e0a316d9c5803a9fa803",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3233,
         "digest": "sha256:90803657434b6e5c7e376160ba2b52527148851a50ddc52e3974b10328e39c1b",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3233,
         "digest": "sha256:227f0139b686a8dabd2ed77b80e109ae123a41102dca6d481922431bfeef0b08",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```

</details>

---

*This PR was authored with [Claude Code](https://claude.ai/code).*
